### PR TITLE
fix: symlink buffer size

### DIFF
--- a/statx.c
+++ b/statx.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 {
     int ret;
     char file_type = '?';
-    char symlink[1024];
+    char symlink[10240];
     int atflag = AT_SYMLINK_NOFOLLOW;
     unsigned int mask = STATX_ALL;
     struct statx stx;


### PR DESCRIPTION
symlink buffer size was increased as in some cases statx was printing out null/invalid chars in symlinks.

0|/usr/share/man/man3/X509_NAME_ENTRY_create_by_OBJ.3ossl.gz -> X509_NAME_ENTRY_get_object.3ossl.gz[NULL_CHARS_HERE]|35237|lrwxrwxrwx|0|0|35|1697027335|1685539502|1697027252|1697027252