### PR TITLE
clear buffer before re-use in readlink()

### DIFF
--- a/statx.c
+++ b/statx.c
@@ -49,6 +49,7 @@ int main(int argc, char **argv)
         printf("0");
 
         // name
+	memset(&symlink, 0, sizeof(symlink));
         ret = readlink(argv[i], symlink, sizeof(symlink));
         if (ret > 0)
             printf("|%s -> %s", argv[i], symlink);


### PR DESCRIPTION
readlink() does not null terminate the path name it returns. The `symlink` buffer accumulates garbage each time through the loop and will output erroneous entries as a result. Nulling the buffer before calling readlink() is safer and fixes the output issue.