### PR TITLE
Implement special permissions in statx output

### DIFF
--- a/statx.c
+++ b/statx.c
@@ -97,13 +97,13 @@ int main(int argc, char **argv)
             printf("%c%c%c%c%c%c%c%c%c",
                 stx.stx_mode & S_IRUSR ? 'r' : '-',
                 stx.stx_mode & S_IWUSR ? 'w' : '-',
-                stx.stx_mode & S_IXUSR ? 'x' : '-',
+                stx.stx_mode & S_IXUSR ? ( stx.stx_mode & S_ISUID  ?'s' : 'x' ) : ( stx.stx_mode & S_ISUID  ?'S' : '-' ),
                 stx.stx_mode & S_IRGRP ? 'r' : '-',
                 stx.stx_mode & S_IWGRP ? 'w' : '-',
-                stx.stx_mode & S_IXGRP ? 'x' : '-',
+                stx.stx_mode & S_IXGRP ? ( stx.stx_mode & S_ISGID  ?'s' : 'x' ) : ( stx.stx_mode & S_ISGID  ?'S' : '-' ),
                 stx.stx_mode & S_IROTH ? 'r' : '-',
                 stx.stx_mode & S_IWOTH ? 'w' : '-',
-                stx.stx_mode & S_IXOTH ? 'x' : '-');
+                stx.stx_mode & S_IXOTH ? ( stx.stx_mode & S_ISVTX  ?'t' : 'x' ) : ( stx.stx_mode & S_ISVTX  ?'T' : '-' ));
         else
             printf("?????????");
 


### PR DESCRIPTION
Previously, the statx binary did not parse the special permissions returned by syscall statx

When working only on timelines, it masquerades the true permissions on files.

The current patch add the parsing of stx_mode with the flags hereafter (inode(7)) and display them accordingly to the output of ls(1):

           S_ISUID     04000   set-user-ID bit
           S_ISGID     02000   set-group-ID bit
           S_ISVTX     01000   sticky bit

To extensively test it, you can run this script:

for i in $(seq 0 4095) ;
do
        mode=$(printf "%0.4o" $i)
        touch $mode
        mkdir d$mode
        chmod $mode $mode
        chmod $mode d$mode
done
